### PR TITLE
feat(docs): Propose Sacred Gardener's Log

### DIFF
--- a/docs/public/SACRED_GARDENERS_LOG_PROPOSAL.md
+++ b/docs/public/SACRED_GARDENERS_LOG_PROPOSAL.md
@@ -1,0 +1,44 @@
+# Proposal: The Sacred Gardener's Log
+
+This document proposes the creation of a new artifact and process for the Hive: the "Sacred Gardener's Log".
+
+## 1. Purpose
+
+The "Sacred Gardener's Log" will serve as a periodic report on the health of the Hive's "garden" of open issues and pull requests. Its purpose is to:
+
+*   Provide a regular, structured analysis of the project's open tasks.
+*   Identify stale, superseded, or blocked issues and PRs that need to be "pruned".
+*   Offer a high-level, multi-dimensional summary of the remaining work.
+*   Improve the overall observability and maintainability of the project.
+
+## 2. The Chronicler as Gardener
+
+The creation and maintenance of the Sacred Gardener's Log will be the responsibility of **`/bee.Chronicler`**. This aligns with the Chronicler's role as the keeper of records and the historian of the Hive. In this capacity, the Chronicler acts as a "gardener", tending to the project's open tasks and ensuring the garden does not become overgrown with weeds.
+
+## 3. Structure of the Log
+
+Each entry in the Sacred Gardener's Log will be a new markdown file, named with the date of the review (e.g., `GARDEN_CLEANUP_LOG_YYYY-MM-DD.md`). The log will contain the following sections:
+
+*   **Header:** The date of the review and the name of the Chronicler who performed it.
+*   **Pruning Summary:** A list of all issues and PRs that were closed ("pruned") during the review, with a brief justification for each closure.
+*   **3-Dimensional Issue Summary:** A table that provides a multi-dimensional analysis of the remaining open issues, assessing them on:
+    *   **Impact/Priority:** The importance of the issue to the Hive's mission.
+    *   **Effort/Complexity:** An estimate of the work required.
+    *   **ATCG Dimension:** The primary architectural primitive the issue relates to.
+*   **Garden Health Assessment:** A concluding statement on the overall health of the project's "garden".
+
+## 4. Process
+
+1.  At regular intervals (or when requested), `/bee.Chronicler` will initiate a "Garden Cleanup" side quest.
+2.  The Chronicler will analyze all open issues and PRs.
+3.  A new "Sacred Gardener's Log" entry will be created as a markdown file in `docs/reviews/`.
+4.  The log will be submitted as a pull request for bee-to-peer review.
+
+## 5. Benefits to the Hive
+
+*   **Improved Focus:** By regularly pruning stale and irrelevant tasks, the team can better focus on what is truly important.
+*   **Enhanced Observability:** The logs will provide a historical record of the project's health and progress over time.
+*   **Better Project Management:** The 3D summary of open issues will help with prioritization and sprint planning.
+*   **Reinforces Hive Principles:** The process of creating and reviewing the log reinforces our commitment to observability, collaboration, and continuous improvement.
+
+This proposal is now ready for bee-to-peer review.


### PR DESCRIPTION
This PR proposes the creation of the Sacred Gardener's Log, a new artifact and process for periodically reviewing and cleaning up open issues and pull requests.